### PR TITLE
Make script usable with NVM installs

### DIFF
--- a/scripts/linux/dc-patcher
+++ b/scripts/linux/dc-patcher
@@ -86,7 +86,7 @@ then
     echo "Installing missing dependencies..."
     if [ -x "$(command -v npm)" ]
     then
-        sudo npm install -g asar
+        npm install -g asar
     else
         >&2 echo "Can't install dependencies automatically. Please install 'asar' manually."
         exit 1

--- a/scripts/linux/dc-patcher
+++ b/scripts/linux/dc-patcher
@@ -86,7 +86,13 @@ then
     echo "Installing missing dependencies..."
     if [ -x "$(command -v npm)" ]
     then
-        npm install -g asar
+        if [ -w "$(npm list -g | head -n 1)" ]
+        then
+            npm install -g asar
+        else
+            sudo npm install -g asar
+        fi
+
     else
         >&2 echo "Can't install dependencies automatically. Please install 'asar' manually."
         exit 1


### PR DESCRIPTION
Systems where node is managed through NVM aren't system installs and sudo don't recognize the `npm` command.

This PR removes the sudo call when installing the asar dependency. For system installs of Node.js. Maybe there's ground for improvement by checking whether the install is local or system, however I figured the script could be called from an elevated prompt.